### PR TITLE
Update to recursive folder queries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,48 @@ Run graphql query
 }
 ```
 
+Contents of folders can be nested. NOTE This is currently extremley inefficient. See todo.
+
+
+```
+{
+  ls(path: "/") {
+    folders {
+      name
+      path
+      files {
+        name
+      }
+      folders {
+        name
+        path
+        files {
+          name
+        }
+        folders {
+          name
+          path
+          files {
+            name
+          }
+          folders {
+            name
+            path
+          }
+        }
+      }
+    }
+    files {
+      name
+    }
+  }
+}
+```
+
 ## TODO
-- Recurring queries not yet supported in `folders`
-- Display contents fo a file
+- Rewrite to fetch entire dropbox directory recursively
+- Validate the ls args - needs to start with `/`
+- Display contents of a file
 - Tree
 - Subscritions to update result on changes
 

--- a/src/gbox/dropbox.clj
+++ b/src/gbox/dropbox.clj
@@ -20,10 +20,14 @@
       (json/decode body keyword))))
 
 (defn ls [dropbox path]
-  (req dropbox "files/list_folder" {:path path :recursive false}))
+  (let [rnf (fn [m] (clojure.set/rename-keys m {"folder" :folders
+                                                "file" :files}))]
+    (->> (req dropbox "files/list_folder" {:path path :recursive false})
+         :entries
+         (group-by :.tag)
+         rnf)))
 
 (defmethod ig/init-key :client/dropbox [_ opts]
   (assoc opts :dropbox-access-token (env :dropbox-access-token)))
 
-;(defmethod ig/halt-key! :client/dropbox [_ _])
 

--- a/src/gbox/gql.clj
+++ b/src/gbox/gql.clj
@@ -15,32 +15,28 @@
       (select-keys [:name :path_lower])
       (clojure.set/rename-keys {:path_lower :path})))
 
-(defn resolve-file [context args value]
-    (map dropbox->gbox (value "file")))
+(defn resolve-file [dropbox]
+  (fn [context args value]
+    (map dropbox->gbox (:files (dbx/ls dropbox (:path value))))))
 
-(defn resolve-folder [context args value]
-    (map dropbox->gbox (value "folder")))
+(defn resolve-folder [dropbox]
+  (fn [context args value]
+    (map dropbox->gbox (:folders (dbx/ls dropbox (:path value))))))
 
 (defn resolve-ls [dropbox]
   (fn [context args value]
-    (let [path (if (= "/" (:path args)) "" (:path args) )]
-      (->> (dbx/ls dropbox path)
-           :entries
-           (group-by :.tag)))))
+    (let [path (if (= "/" (:path args)) {:path ""} args )]
+      path)))
 
 (defn gbox-schema [dropbox]
   (-> "gbox-schema.edn"
       slurp
       edn/read-string
       (util/attach-resolvers {:resolve-ls (resolve-ls dropbox)
-                              :resolve-file resolve-file
-                              :resolve-folder resolve-folder})
+                              :resolve-file (resolve-file dropbox)
+                              :resolve-folder (resolve-folder dropbox)})
       schema/compile))
 
 (defmethod ig/init-key :handler/gql [_ opts]
-  {:schema (gbox-schema (:dropbox opts))}
-  )
-
-;(defmethod ig/halt-key! :hanler/gql [_ _]
-;  )
+  {:schema (gbox-schema (:dropbox opts))})
 


### PR DESCRIPTION
This is the second iteration which provides the ability to nest `files` and `folders` into the top level `folders` result. See updates to readme.
This is not a good way to do this, the next iteration would require fetching the entire directory tree once when the `ls` query is run and resolving it recursively.